### PR TITLE
Fix stray artifacts in Airtable API handler

### DIFF
--- a/api/submit-lead.js
+++ b/api/submit-lead.js
@@ -11,16 +11,10 @@ export default async function handler(req, res) {
     return res.status(400).json({ error: 'Missing name or email' });
   }
 
- h5n9gu-codex/troubleshoot-api-connection-to-airtable
   // Airtable credentials are provided via environment variables in Vercel
   const airtableApiKey = process.env.AIRTABLE_API_KEY;
   const baseId = process.env.AIRTABLE_BASE_ID || 'appulB9SOqm16pklS';
   const tableName = process.env.AIRTABLE_TABLE_NAME || 'Leads';
-
-  const airtableApiKey = process.env.AIRTABLE_API_KEY;
-  const baseId = 'appulB9SOqm16pklS';
-  const tableName = 'Leads';
-main
 
   try {
     const response = await fetch(`https://api.airtable.com/v0/${baseId}/${tableName}`, {
@@ -32,12 +26,8 @@ main
       body: JSON.stringify({
         fields: {
           Name: name,
- h5n9gu-codex/troubleshoot-api-connection-to-airtable
           Email: email,
           'Submitted At': new Date().toISOString()
-
-          Email: email
- main
         }
       })
     });


### PR DESCRIPTION
## Summary
- cleanup `api/submit-lead.js` to remove merge leftovers
- ensure environment variables are used and fetch call is valid

## Testing
- `node -e "require('./api/submit-lead.js'); console.log('ok');"`

------
https://chatgpt.com/codex/tasks/task_e_684c5a71e6b483289659b5a585802ff9