### PR TITLE
Add contact page

### DIFF
--- a/api/submit-lead.js
+++ b/api/submit-lead.js
@@ -5,7 +5,7 @@ export default async function handler(req, res) {
     return res.status(405).json({ error: 'Method not allowed' });
   }
 
-  const { name, email } = req.body;
+  const { name, email, message } = req.body;
 
   if (!name || !email) {
     return res.status(400).json({ error: 'Missing name or email' });
@@ -27,6 +27,7 @@ export default async function handler(req, res) {
         fields: {
           Name: name,
           Email: email,
+          ...(message ? { Message: message } : {}),
           'Submitted At': new Date().toISOString()
         }
       })

--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Contact - InvestorProps</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <nav class="nav-bar">
+    <div class="nav-logo">InvestorProps</div>
+    <ul class="nav-links">
+      <li><a href="index.html" class="nav-link">Home</a></li>
+      <li><a href="home.html#features" class="nav-link">Features</a></li>
+      <li><a href="home.html#pricing" class="nav-link">Pricing</a></li>
+      <li><a href="contact.html" class="nav-link">Contact</a></li>
+      <li><a href="index.html" class="nav-link btn-primary">Launch ROI Finder</a></li>
+    </ul>
+  </nav>
+
+  <section class="hero-section">
+    <div class="hero-content">
+      <h1>Contact Us</h1>
+      <form class="hero-lead-form" id="contact-form">
+        <input type="text" name="name" placeholder="Your Name" required />
+        <input type="email" name="email" placeholder="Your Email" required />
+        <textarea name="message" placeholder="Your Message" required></textarea>
+        <button type="submit">Send Message</button>
+      </form>
+    </div>
+  </section>
+
+  <footer class="footer" id="footer">
+    &copy; 2025 InvestorProps. All rights reserved.
+  </footer>
+
+  <script>
+    document.getElementById('contact-form').addEventListener('submit', async function(e) {
+      e.preventDefault();
+      const name = this.name.value;
+      const email = this.email.value;
+      const message = this.message.value;
+      const response = await fetch('/api/submit-lead', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, email, message })
+      });
+      if (response.ok) {
+        alert('Thanks for reaching out!');
+        this.reset();
+      } else {
+        alert('Oops! Something went wrong.');
+      }
+    });
+  </script>
+</body>
+</html>

--- a/home.html
+++ b/home.html
@@ -13,7 +13,7 @@
       <li><a href="home.html" class="nav-link">Home</a></li>
       <li><a href="#features" class="nav-link">Features</a></li>
       <li><a href="#pricing" class="nav-link">Pricing</a></li>
-      <li><a href="#footer" class="nav-link">Contact</a></li>
+      <li><a href="contact.html" class="nav-link">Contact</a></li>
       <li><a href="index.html" class="nav-link btn-primary">Launch ROI Finder</a></li>
     </ul>
   </nav>

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
       <li><a href="index.html" class="nav-link">Home</a></li>
       <li><a href="#features" class="nav-link">Features</a></li>
       <li><a href="#pricing" class="nav-link">Pricing</a></li>
-      <li><a href="#footer" class="nav-link">Contact</a></li>
+      <li><a href="contact.html" class="nav-link">Contact</a></li>
       <li><a href="index.html" class="nav-link btn-primary">Launch ROI Finder</a></li>
     </ul>
   </nav>

--- a/styles.css
+++ b/styles.css
@@ -61,11 +61,15 @@ body {
   margin: 2rem auto 0 auto;
 }
 .hero-lead-form input,
+.hero-lead-form textarea,
 .hero-lead-form button {
   padding: 12px;
   font-size: 1rem;
   border-radius: 8px;
   border: 1px solid #ccc;
+}
+.hero-lead-form textarea {
+  min-height: 120px;
 }
 .hero-lead-form button {
   background-color: #16a34a;


### PR DESCRIPTION
## Summary
- create standalone `contact.html` with a contact form
- update navigation links on existing pages to point to the new page
- extend `submit-lead` API to store optional messages
- tweak styles for forms to support textarea fields

## Testing
- `node --check app.js`
- `node --check api/submit-lead.js`


------
https://chatgpt.com/codex/tasks/task_e_684c5ea49fd883289cdb4dc388df3e95