### PR TITLE
Add homepage mockup designs

### DIFF
--- a/mockups/homepage-mockup1.html
+++ b/mockups/homepage-mockup1.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Homepage Mockup 1 - Classic Hero</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-50">
+  <!-- Header -->
+  <header class="bg-white shadow">
+    <div class="max-w-6xl mx-auto px-4 py-4 flex justify-between items-center">
+      <h1 class="text-2xl font-bold text-blue-600">StarterPack</h1>
+      <nav class="space-x-4 text-gray-600">
+        <a href="#" class="hover:text-blue-600">Features</a>
+        <a href="#" class="hover:text-blue-600">Pricing</a>
+        <a href="#" class="hover:text-blue-600">Contact</a>
+      </nav>
+    </div>
+  </header>
+
+  <!-- Hero -->
+  <section class="bg-blue-600 text-white">
+    <div class="max-w-6xl mx-auto px-4 py-24 text-center">
+      <h2 class="text-4xl md:text-5xl font-extrabold mb-4">Launch Your Next Project Faster</h2>
+      <p class="text-lg md:text-xl mb-8">All the tools you need to kickstart your startup in one place.</p>
+      <a href="#" class="bg-white text-blue-600 font-semibold px-8 py-3 rounded shadow hover:bg-gray-100">Get Started</a>
+    </div>
+  </section>
+
+  <!-- Features -->
+  <section class="max-w-6xl mx-auto px-4 py-16 grid md:grid-cols-3 gap-8">
+    <div class="bg-white p-6 rounded-lg shadow">
+      <h3 class="text-xl font-bold mb-2">Fast Setup</h3>
+      <p class="text-gray-600">Jumpstart your project with pre‑built components and templates.</p>
+    </div>
+    <div class="bg-white p-6 rounded-lg shadow">
+      <h3 class="text-xl font-bold mb-2">Scalable</h3>
+      <p class="text-gray-600">Grow confidently with a foundation designed for scale.</p>
+    </div>
+    <div class="bg-white p-6 rounded-lg shadow">
+      <h3 class="text-xl font-bold mb-2">Community</h3>
+      <p class="text-gray-600">Connect with other makers for support and collaboration.</p>
+    </div>
+  </section>
+
+  <!-- Footer -->
+  <footer class="bg-gray-100 py-8 text-center text-gray-500 text-sm">
+    © 2025 StarterPack. All rights reserved.
+  </footer>
+</body>
+</html>

--- a/mockups/homepage-mockup2.html
+++ b/mockups/homepage-mockup2.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Homepage Mockup 2 - Image Hero</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-50">
+  <!-- Header -->
+  <header class="absolute w-full z-10">
+    <div class="max-w-6xl mx-auto px-4 py-4 flex justify-between items-center text-white">
+      <h1 class="text-2xl font-bold">StarterPack</h1>
+      <nav class="space-x-4">
+        <a href="#" class="hover:text-blue-200">Product</a>
+        <a href="#" class="hover:text-blue-200">About</a>
+        <a href="#" class="hover:text-blue-200">Login</a>
+      </nav>
+    </div>
+  </header>
+
+  <!-- Hero with background image -->
+  <section class="relative h-screen flex items-center justify-center text-center text-white">
+    <img src="https://source.unsplash.com/1600x900/?startup" alt="startup" class="absolute inset-0 w-full h-full object-cover" />
+    <div class="absolute inset-0 bg-blue-900/60"></div>
+    <div class="relative z-10 max-w-2xl px-4">
+      <h2 class="text-4xl md:text-5xl font-extrabold mb-6">Build Something Great</h2>
+      <p class="text-lg md:text-xl mb-8">Starter templates and resources to supercharge your productivity.</p>
+      <a href="#" class="bg-blue-500 hover:bg-blue-400 text-white font-semibold px-8 py-3 rounded">Explore Now</a>
+    </div>
+  </section>
+
+  <!-- Footer -->
+  <footer class="bg-gray-100 py-8 text-center text-gray-500 text-sm">
+    © 2025 StarterPack. All rights reserved.
+  </footer>
+</body>
+</html>

--- a/mockups/homepage-mockup3.html
+++ b/mockups/homepage-mockup3.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Homepage Mockup 3 - Split Layout</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-50">
+  <!-- Header -->
+  <header class="bg-white shadow">
+    <div class="max-w-6xl mx-auto px-4 py-4 flex justify-between items-center">
+      <h1 class="text-2xl font-bold text-blue-600">StarterPack</h1>
+      <nav class="space-x-4 text-gray-600">
+        <a href="#" class="hover:text-blue-600">Docs</a>
+        <a href="#" class="hover:text-blue-600">Community</a>
+        <a href="#" class="hover:text-blue-600">Sign In</a>
+      </nav>
+    </div>
+  </header>
+
+  <!-- Split Hero -->
+  <section class="flex flex-col md:flex-row max-w-6xl mx-auto px-4 py-16 items-center">
+    <div class="md:w-1/2 mb-12 md:mb-0 md:pr-8">
+      <h2 class="text-4xl font-extrabold text-gray-900 mb-4">Everything you need to launch</h2>
+      <p class="text-gray-600 mb-6">StarterPack brings together design, code, and community so you can go from idea to launch faster.</p>
+      <a href="#" class="bg-blue-600 text-white px-8 py-3 rounded font-semibold hover:bg-blue-500">Join Free</a>
+    </div>
+    <div class="md:w-1/2">
+      <img src="https://source.unsplash.com/600x400/?workspace" alt="workspace" class="rounded shadow-lg" />
+    </div>
+  </section>
+
+  <!-- Footer -->
+  <footer class="bg-gray-100 py-8 text-center text-gray-500 text-sm">
+    © 2025 StarterPack. All rights reserved.
+  </footer>
+</body>
+</html>

--- a/mockups/homepage-mockup4.html
+++ b/mockups/homepage-mockup4.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Homepage Mockup 4 - Minimal CTA</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-white">
+  <div class="min-h-screen flex flex-col items-center justify-center text-center px-4">
+    <h1 class="text-5xl md:text-6xl font-extrabold text-gray-900 mb-6">Start Building Today</h1>
+    <p class="text-lg md:text-xl text-gray-600 mb-10 max-w-2xl">A lightweight starter kit for entrepreneurs and developers who want to move fast and stay focused.</p>
+    <div class="space-x-4">
+      <a href="#" class="bg-blue-600 text-white px-8 py-3 rounded font-semibold hover:bg-blue-500">Create Account</a>
+      <a href="#" class="text-blue-600 font-semibold hover:underline">Learn More</a>
+    </div>
+  </div>
+  <footer class="bg-gray-100 py-8 text-center text-gray-500 text-sm">
+    © 2025 StarterPack. All rights reserved.
+  </footer>
+</body>
+</html>

--- a/mockups/index.html
+++ b/mockups/index.html
@@ -118,6 +118,31 @@
             </a>
         </div>
         
+        <!-- Homepage Mockups -->
+        <h2 class="text-2xl font-bold text-gray-900 mb-4 mt-12">Homepage Mockups</h2>
+
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <a href="homepage-mockup1.html" target="_blank" class="block bg-white rounded-lg shadow-lg p-6 hover:shadow-xl transition-shadow">
+                <h2 class="text-xl font-bold text-blue-600 mb-2">Homepage 1: Classic Hero</h2>
+                <p class="text-gray-600 text-sm">Header, hero, and three feature cards.</p>
+            </a>
+
+            <a href="homepage-mockup2.html" target="_blank" class="block bg-white rounded-lg shadow-lg p-6 hover:shadow-xl transition-shadow">
+                <h2 class="text-xl font-bold text-purple-600 mb-2">Homepage 2: Image Hero</h2>
+                <p class="text-gray-600 text-sm">Full-screen background image with overlay.</p>
+            </a>
+
+            <a href="homepage-mockup3.html" target="_blank" class="block bg-white rounded-lg shadow-lg p-6 hover:shadow-xl transition-shadow">
+                <h2 class="text-xl font-bold text-green-600 mb-2">Homepage 3: Split Layout</h2>
+                <p class="text-gray-600 text-sm">Half text, half image hero with call to action.</p>
+            </a>
+
+            <a href="homepage-mockup4.html" target="_blank" class="block bg-white rounded-lg shadow-lg p-6 hover:shadow-xl transition-shadow">
+                <h2 class="text-xl font-bold text-amber-600 mb-2">Homepage 4: Minimal CTA</h2>
+                <p class="text-gray-600 text-sm">Simple centered headline with primary action.</p>
+            </a>
+        </div>
+
         <div class="mt-8 p-4 bg-gray-100 rounded-lg">
             <p class="text-sm text-gray-600">
                 <strong>Note:</strong> These mockups are static HTML files. To view them, you can:


### PR DESCRIPTION
## Summary
- add four standalone HTML mockups for potential homepage designs
- link new mockup files from `mockups/index.html` for easy review

## Testing
- `npm test` *(fails: Module <rootDir>/tests/setup.js in the setupFilesAfterEnv option was not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ec835c1e48328b9e3b5ebe0128246